### PR TITLE
Update stop API to optionally clear Places data

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,7 +15,7 @@ coverage:
   notify:
     slack:
       default:
-        url: "https://hooks.slack.com/services/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"
+        url: "https://hooks.slack.com/services/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"
         threshold: null
         only_pulls: false
         branches: null

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,7 +15,7 @@ coverage:
   notify:
     slack:
       default:
-        url: "https://hooks.slack.com/services/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"
+        url: "https://hooks.slack.com/services/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"
         threshold: null
         only_pulls: false
         branches: null

--- a/ACPPlacesMonitor.xcodeproj/project.pbxproj
+++ b/ACPPlacesMonitor.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		154F7EF41F8E892A2B2DF51A /* libPods-ACPPlacesMonitor_iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A2A0A78BDE10C42B75E2C830 /* libPods-ACPPlacesMonitor_iOS.a */; };
 		2429BC1E21C1CAD3003DB1A5 /* ACPPlacesMonitor.m in Sources */ = {isa = PBXBuildFile; fileRef = DAFA90061FFD9C6E0069ACAC /* ACPPlacesMonitor.m */; };
 		243E663321FF66A400482882 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = F04CF4EF1FCF7C060071CD3D /* libc++.tbd */; };
-		2488B3C921C4558F00E160DD /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 54E0DE361FC36BA000E96578 /* CoreLocation.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		2488B3C921C4558F00E160DD /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 54E0DE361FC36BA000E96578 /* CoreLocation.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		2488B3CC21C459EA00E160DD /* ACPPlacesMonitorInternal.m in Sources */ = {isa = PBXBuildFile; fileRef = 2488B3CB21C459EA00E160DD /* ACPPlacesMonitorInternal.m */; };
 		2488B3D321C4704200E160DD /* ACPPlacesMonitorInternalTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2488B3D121C46FBE00E160DD /* ACPPlacesMonitorInternalTests.m */; };
 		24C1F987224A8CB6000DF424 /* ACPPlacesMonitorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 24C1F986224A8CB6000DF424 /* ACPPlacesMonitorTests.m */; };
@@ -413,7 +413,7 @@
 			attributes = {
 				DefaultBuildSystemTypeForWorkspace = Original;
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1010;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Adobe Systems Incorporated";
 				TargetAttributes = {
 					2429BC1321C1CA38003DB1A5 = {
@@ -432,6 +432,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -634,6 +635,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -697,6 +699,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -753,6 +756,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";

--- a/ACPPlacesMonitor.xcodeproj/xcshareddata/xcschemes/ACPPlacesMonitor-iOS-unit-tests.xcscheme
+++ b/ACPPlacesMonitor.xcodeproj/xcshareddata/xcschemes/ACPPlacesMonitor-iOS-unit-tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ACPPlacesMonitor.xcodeproj/xcshareddata/xcschemes/ACPPlacesMonitor_iOS.xcscheme
+++ b/ACPPlacesMonitor.xcodeproj/xcshareddata/xcschemes/ACPPlacesMonitor_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ACPPlacesMonitor/ACPPlacesMonitor.h
+++ b/ACPPlacesMonitor/ACPPlacesMonitor.h
@@ -12,7 +12,7 @@
 
 //
 // ACPPlacesMonitor.h
-// Places Monitor Version: 1.0.2
+// Places Monitor Version: 2.0.0
 //
 
 #import <Foundation/Foundation.h>
@@ -91,8 +91,17 @@ typedef NS_OPTIONS(NSInteger, ACPPlacesMonitorMode) {
 
 /**
  * @brief Stop tracking the device's location
+ *
+ * @discussion Calling this method will stop tracking the customer's location.  Additionally, it will unregister
+ * all previously registered regions.  Optionally, you may purge client-side data by passing in YES for the clearData
+ * parameter.
+ *
+ * Calling this method with YES for clearData will purge the data even if the monitor is not actively tracking
+ * the device's location.
+ *
+ * @param clearData pass YES to clear all client-side Places data from the device.
  */
-+ (void) stop;
++ (void) stop: (BOOL) clearData;
 
 /**
  * @brief Immediately gets an update for the device's location

--- a/ACPPlacesMonitor/ACPPlacesMonitor.m
+++ b/ACPPlacesMonitor/ACPPlacesMonitor.m
@@ -50,8 +50,10 @@
     [ACPPlacesMonitor dispatchMonitorEvent:ACPPlacesMonitorEventNameStart withData:@ {}];
 }
 
-+ (void) stop {
-    [ACPPlacesMonitor dispatchMonitorEvent:ACPPlacesMonitorEventNameStop withData:@ {}];
++ (void) stop:(BOOL) clearData {
+    [ACPPlacesMonitor dispatchMonitorEvent:ACPPlacesMonitorEventNameStop withData:@ {
+        ACPPlacesMonitorEventDataClear : @(clearData)
+    }];
 }
 
 + (void) updateLocationNow {

--- a/ACPPlacesMonitor/ACPPlacesMonitorConstants.h
+++ b/ACPPlacesMonitor/ACPPlacesMonitorConstants.h
@@ -59,6 +59,7 @@ FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventNameStop;
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventNameUpdateLocationNow;
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventNameUpdateMonitorConfiguration;
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventDataMonitorMode;
+FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventDataClear;
 
 
 #pragma mark - capability definitions by platform

--- a/ACPPlacesMonitor/ACPPlacesMonitorConstants.m
+++ b/ACPPlacesMonitor/ACPPlacesMonitorConstants.m
@@ -17,7 +17,7 @@
 #import "ACPPlacesMonitorConstants.h"
 
 #pragma mark - Monitor Properties
-NSString* const ACPPlacesMonitorExtensionVersion = @"1.0.2";
+NSString* const ACPPlacesMonitorExtensionVersion = @"2.0.0";
 NSString* const ACPPlacesMonitorExtensionName = @"com.adobe.placesMonitor";
 int const ACPPlacesMonitorDefaultMaxMonitoredRegionCount = 20;
 
@@ -57,3 +57,4 @@ NSString* const ACPPlacesMonitorEventNameStop = @"stop monitoring";
 NSString* const ACPPlacesMonitorEventNameUpdateLocationNow = @"update location now";
 NSString* const ACPPlacesMonitorEventNameUpdateMonitorConfiguration = @"update monitor configuration";
 NSString* const ACPPlacesMonitorEventDataMonitorMode = @"monitormode";
+NSString* const ACPPlacesMonitorEventDataClear = @"clearclientdata";

--- a/ACPPlacesMonitor/ACPPlacesMonitorInternal.h
+++ b/ACPPlacesMonitor/ACPPlacesMonitorInternal.h
@@ -42,8 +42,17 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Location Settings and State
 /**
  * @brief Immediately causing the monitor to stop tracking the device's location and monitoring regions
+ *
+ * @discussion Calling this method will stop tracking the customer's location.  Additionally, it will unregister
+ * all previously registered regions.  Optionally, you may purge client-side data by passing in YES for the clearData
+ * parameter.
+ *
+ * Calling this method with YES for clearData will purge the data even if the monitor is not actively tracking
+ * the device's location.
+ *
+ * @param clearData pass YES to clear all client-side Places data from the device.
  */
-- (void) stopAllMonitoring;
+- (void) stopAllMonitoring: (BOOL) clearData;
 
 /**
  * @brief Adds the provided region to a list of regions that the device is currently within

--- a/ACPPlacesMonitor/ACPPlacesMonitorInternal.m
+++ b/ACPPlacesMonitor/ACPPlacesMonitorInternal.m
@@ -205,7 +205,8 @@
         if ([eventToProcess.eventName isEqualToString:ACPPlacesMonitorEventNameStart]) {
             [self startMonitoring];
         } else if ([eventToProcess.eventName isEqualToString:ACPPlacesMonitorEventNameStop]) {
-            [self stopAllMonitoring];
+            bool clearData = [[eventToProcess.eventData objectForKey:ACPPlacesMonitorEventDataClear] boolValue] ?: NO;
+            [self stopAllMonitoring:clearData];
         } else if ([eventToProcess.eventName isEqualToString:ACPPlacesMonitorEventNameUpdateLocationNow]) {
             [self updateLocationNow];
         } else if ([eventToProcess.eventName isEqualToString:ACPPlacesMonitorEventNameUpdateMonitorConfiguration]) {
@@ -219,7 +220,16 @@
 }
 
 #pragma mark - Location Settings and State
-- (void) stopAllMonitoring {
+- (void) stopAllMonitoring: (BOOL) clearData {
+    [ACPCore log:ACPMobileLogLevelVerbose
+             tag:ACPPlacesMonitorExtensionName
+         message:[NSString stringWithFormat:@"Stopping all monitoring. Client-side data will %@be purged",
+                  clearData ? @"" : @"not "]];
+    
+    if (clearData) {
+        [ACPPlaces clear];
+    }
+    
 #if CONTINUOUS_LOCATION_SUPPORTED
     [self stopMonitoringContinuousLocationChanges];
 #endif

--- a/ACPPlacesMonitor/ACPPlacesMonitorLocationDelegate.m
+++ b/ACPPlacesMonitor/ACPPlacesMonitorLocationDelegate.m
@@ -37,7 +37,7 @@
 
     // if we get this error, all location activity should end
     if (error.code == kCLErrorDenied) {
-        [_parent stopAllMonitoring];
+        [_parent stopAllMonitoring:YES];
         [ACPCore log:ACPMobileLogLevelDebug
                  tag:ACPPlacesMonitorExtensionName
              message:[NSString stringWithFormat:@"Places functionality has been suspended due to a monitoring failure: %@", error]];

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,11 +2,11 @@ PODS:
   - ACPCore (2.3.2):
     - ACPCore/iOS (= 2.3.2)
   - ACPCore/iOS (2.3.2)
-  - ACPPlaces (1.1.0):
-    - ACPCore (>= 2.2.2)
-    - ACPPlaces/iOS (= 1.1.0)
-  - ACPPlaces/iOS (1.1.0):
-    - ACPCore (>= 2.2.2)
+  - ACPPlaces (1.2.0):
+    - ACPCore (>= 2.3.2)
+    - ACPPlaces/iOS (= 1.2.0)
+  - ACPPlaces/iOS (1.2.0):
+    - ACPCore (>= 2.3.2)
   - OCMock (3.4.3)
 
 DEPENDENCIES:
@@ -22,7 +22,7 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   ACPCore: 4461c6462adec0e103d6fc1e9bdc21dee8a991e0
-  ACPPlaces: 2edcd31da17390c6b8a38d8e472968334ece7f20
+  ACPPlaces: 35401daa06d6b4bb9cfb91cce62e07d871aa0f10
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
 
 PODFILE CHECKSUM: e6b5f1a437e9254655924c3febf1f623ef768d43

--- a/tests/ACPPlacesMonitorInternalTests.m
+++ b/tests/ACPPlacesMonitorInternalTests.m
@@ -323,13 +323,13 @@
     OCMVerify([_monitor startMonitoring]);
 }
 
-- (void) testProcessEventsStopEvent {
+- (void) testProcessEventsStopEventWithClear {
     // setup
     NSError* eventCreationError = nil;
     ACPExtensionEvent* event = [ACPExtensionEvent extensionEventWithName:ACPPlacesMonitorEventNameStop_Test
                                                                     type:ACPPlacesMonitorEventTypeMonitor_Test
                                                                   source:ACPPlacesMonitorEventSourceRequestContent_Test
-                                                                    data:nil
+                                                                    data:@{ACPPlacesMonitorEventDataClear:@(YES)}
                                                                    error:&eventCreationError];
     [_monitor.eventQueue add:event];
     
@@ -338,7 +338,25 @@
     
     // verify
     XCTAssertNil([_monitor.eventQueue peek]);
-    OCMVerify([_monitor stopAllMonitoring]);
+    OCMVerify([_monitor stopAllMonitoring:YES]);
+}
+
+- (void) testProcessEventsStopEventWithoutClear {
+    // setup
+    NSError* eventCreationError = nil;
+    ACPExtensionEvent* event = [ACPExtensionEvent extensionEventWithName:ACPPlacesMonitorEventNameStop_Test
+                                                                    type:ACPPlacesMonitorEventTypeMonitor_Test
+                                                                  source:ACPPlacesMonitorEventSourceRequestContent_Test
+                                                                    data:@{ACPPlacesMonitorEventDataClear:@(NO)}
+                                                                   error:&eventCreationError];
+    [_monitor.eventQueue add:event];
+    
+    // test
+    [_monitor processEvents];
+    
+    // verify
+    XCTAssertNil([_monitor.eventQueue peek]);
+    OCMVerify([_monitor stopAllMonitoring:NO]);
 }
 
 - (void) testProcessEventsUpdateLocationNowEvent {
@@ -395,11 +413,23 @@
     OCMVerify([_monitor setMonitorMode:ACPPlacesMonitorModeSignificantChanges]);
 }
 
-- (void) testStopAllMonitoring {
+- (void) testStopAllMonitoringWithClear {
     // test
-    [_monitor stopAllMonitoring];
+    [_monitor stopAllMonitoring:YES];
     
     // verify
+    OCMVerify([_placesMock clear]);
+    OCMVerify([_monitor stopMonitoringContinuousLocationChanges]);
+    OCMVerify([_monitor stopMonitoringSignificantLocationChanges]);
+    OCMVerify([_monitor stopMonitoringGeoFences]);
+}
+
+- (void) testStopAllMonitoringWithoutClear {
+    // test
+    [_monitor stopAllMonitoring:NO];
+    
+    // verify
+    OCMReject([_placesMock clear]);
     OCMVerify([_monitor stopMonitoringContinuousLocationChanges]);
     OCMVerify([_monitor stopMonitoringSignificantLocationChanges]);
     OCMVerify([_monitor stopMonitoringGeoFences]);

--- a/tests/ACPPlacesMonitorLocationDelegateTests.m
+++ b/tests/ACPPlacesMonitorLocationDelegateTests.m
@@ -104,7 +104,7 @@
     OCMVerify([_coreMock log:ACPMobileLogLevelWarning
                          tag:ACPPlacesMonitorExtensionName_Test
                      message:[OCMArg any]]);
-    OCMVerify([_placesMock stopAllMonitoring]);
+    OCMVerify([_placesMock stopAllMonitoring:YES]);
     OCMVerify([_coreMock log:ACPMobileLogLevelDebug
                          tag:ACPPlacesMonitorExtensionName_Test
                      message:[OCMArg any]]);

--- a/tests/ACPPlacesMonitorTests.m
+++ b/tests/ACPPlacesMonitorTests.m
@@ -108,13 +108,22 @@
                                         withData:@{}]);
 }
 
-- (void) testStop {
+- (void) testStopWithClear {
     // test
-    [ACPPlacesMonitor stop];
+    [ACPPlacesMonitor stop:YES];
     
     // verify
     OCMVerify([_monitorMock dispatchMonitorEvent:ACPPlacesMonitorEventNameStop_Test
-                                        withData:@{}]);
+                                        withData:@{ACPPlacesMonitorEventDataClear: @(YES)}]);
+}
+
+- (void) testStopWithoutClear {
+    // test
+    [ACPPlacesMonitor stop:NO];
+    
+    // verify
+    OCMVerify([_monitorMock dispatchMonitorEvent:ACPPlacesMonitorEventNameStop_Test
+                                        withData:@{ACPPlacesMonitorEventDataClear: @(NO)}]);
 }
 
 - (void) testUpdateLocationNow {

--- a/tests/mocks/ACPPlacesMonitorConstantsTests.h
+++ b/tests/mocks/ACPPlacesMonitorConstantsTests.h
@@ -18,7 +18,7 @@
 #define ACPPlacesMonitorConstantsTests_h
 
 #pragma mark - Monitor Properties
-static NSString* const ACPPlacesMonitorExtensionVersion_Test = @"1.0.2";
+static NSString* const ACPPlacesMonitorExtensionVersion_Test = @"2.0.0";
 static NSString* const ACPPlacesMonitorExtensionName_Test = @"com.adobe.placesMonitor";
 static int const ACPPlacesMonitorDefaultMaxMonitoredRegionCount_Test = 20;
 
@@ -58,5 +58,6 @@ static NSString* const ACPPlacesMonitorEventNameStop_Test = @"stop monitoring";
 static NSString* const ACPPlacesMonitorEventNameUpdateLocationNow_Test = @"update location now";
 static NSString* const ACPPlacesMonitorEventNameUpdateMonitorConfiguration_Test = @"update monitor configuration";
 static NSString* const ACPPlacesMonitorEventDataMonitorMode_Test = @"monitormode";
+static NSString* const ACPPlacesMonitorEventDataClear = @"clearclientdata";
 
 #endif /* ACPPlacesMonitorConstantsTests_h */


### PR DESCRIPTION
## Description

Modified the `stop` API to accept a bool param.  If `YES` is passed, all Places data will be removed from the device.  

Addressing #28 

## Motivation and Context

Location data becomes stale quickly if it is no longer being updated.  Stale data can lead to false positives from the Rules Engine and improper triggering of location-related experiences.  Providing an option to clear data at the time location monitoring is stopped will prevent false positives due to stale location data.

## How Has This Been Tested?

Unit tests.  Manual smoke tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
