### PR TITLE
#21 - Update to get nearby poi API that accepts an error callback

### DIFF
--- a/ACPPlacesMonitor/ACPPlacesMonitorInternal.m
+++ b/ACPPlacesMonitor/ACPPlacesMonitorInternal.m
@@ -294,7 +294,7 @@
                                     } else {
                                         [ACPCore log:ACPMobileLogLevelDebug
                                                  tag:ACPPlacesMonitorExtensionName
-                                             message:@"No nearby Places were retrieved due to a network issue or no POIs near the device location."];
+                                             message:@"There are no POIs near the device location."];
                                     }
                                     
                                     [self removeNonMonitoredRegionsFromUserWithinRegions];

--- a/ACPPlacesMonitor/ACPPlacesMonitorInternal.m
+++ b/ACPPlacesMonitor/ACPPlacesMonitorInternal.m
@@ -312,7 +312,8 @@
     NSString *errorString = nil;
     switch (error) {
         case ACPPlacesRequestErrorConfigurationError:
-            errorString = @"Missing Places configuration. Is the Places extension registered?";
+            errorString = @"Missing Places configuration.";
+            [self stopAllMonitoring:YES];
             break;
         case ACPPlacesRequestErrorConnectivityError:
             errorString = @"No network connectivity.";

--- a/ACPPlacesMonitor/ACPPlacesMonitorInternal.m
+++ b/ACPPlacesMonitor/ACPPlacesMonitorInternal.m
@@ -228,6 +228,7 @@
     
     if (clearData) {
         [ACPPlaces clear];
+        [self clearMonitorData];
     }
     
 #if CONTINUOUS_LOCATION_SUPPORTED
@@ -548,6 +549,17 @@
          message:@"Continuous location collection is disabled"];
 }
 #endif
+
+/**
+ * @brief Removes all objects from currently monitored regions and user within regions, also clears them from persistence.
+ */
+- (void) clearMonitorData {
+    [_currentlyMonitoredRegions removeAllObjects];
+    [self updateCurrentlyMonitoredRegionsInPersistence];
+    
+    [_userWithinRegions removeAllObjects];
+    [self updateUserWithinRegionsInPersistence];
+}
 
 - (BOOL) userHasDeclinedLocationPermission: (CLAuthorizationStatus) status {
     return status == kCLAuthorizationStatusRestricted || status == kCLAuthorizationStatusDenied;

--- a/tests/ACPPlacesMonitorInternalTests.m
+++ b/tests/ACPPlacesMonitorInternalTests.m
@@ -557,7 +557,7 @@
         OCMVerify([self.monitor resetMonitoredGeofences]);
         OCMVerify([self.coreMock log:ACPMobileLogLevelDebug
                              tag:ACPPlacesMonitorExtensionName_Test
-                         message:@"No nearby Places were retrieved due to a network issue or no POIs near the device location."]);
+                         message:@"There are no POIs near the device location."]);
         OCMVerify([self.monitor removeNonMonitoredRegionsFromUserWithinRegions]);
     });
     

--- a/tests/ACPPlacesMonitorInternalTests.m
+++ b/tests/ACPPlacesMonitorInternalTests.m
@@ -37,6 +37,7 @@
 
 - (BOOL) backgroundLocationUpdatesEnabledInBundle;
 - (void) beginTrackingLocation;
+- (void) clearMonitorData;
 - (void) handlePlacesRequestError:(ACPPlacesRequestError) error;
 - (void) loadPersistedValues;
 - (void) removeNonMonitoredRegionsFromUserWithinRegions;
@@ -422,6 +423,7 @@
     
     // verify
     OCMVerify([_placesMock clear]);
+    OCMVerify([_monitor clearMonitorData]);
     OCMVerify([_monitor stopMonitoringContinuousLocationChanges]);
     OCMVerify([_monitor stopMonitoringSignificantLocationChanges]);
     OCMVerify([_monitor stopMonitoringGeoFences]);
@@ -433,6 +435,7 @@
     
     // verify
     OCMReject([_placesMock clear]);
+    OCMReject([_monitor clearMonitorData]);
     OCMVerify([_monitor stopMonitoringContinuousLocationChanges]);
     OCMVerify([_monitor stopMonitoringSignificantLocationChanges]);
     OCMVerify([_monitor stopMonitoringGeoFences]);
@@ -1201,6 +1204,21 @@
     
     // verify
     XCTAssertFalse(result);
+}
+
+- (void) testClearMonitorData {
+    // setup
+    [_monitor.userWithinRegions addObject:_fakeRegion.identifier];
+    [_monitor.currentlyMonitoredRegions addObject:@"5678"];
+    
+    // test
+    [_monitor clearMonitorData];
+    
+    // verify
+    XCTAssertEqual(0, _monitor.currentlyMonitoredRegions.count);
+    OCMVerify([_monitor updateCurrentlyMonitoredRegionsInPersistence]);
+    XCTAssertEqual(0, _monitor.userWithinRegions.count);
+    OCMVerify([_monitor updateUserWithinRegionsInPersistence]);
 }
 
 @end

--- a/tests/ACPPlacesMonitorInternalTests.m
+++ b/tests/ACPPlacesMonitorInternalTests.m
@@ -628,10 +628,11 @@
     [_monitor handlePlacesRequestError:ACPPlacesRequestErrorConfigurationError];
     
     // verify
-    NSString *errorString = @"An error occurred while attempting to retrieve nearby points of interest: Missing Places configuration. Is the Places extension registered?";
+    NSString *errorString = @"An error occurred while attempting to retrieve nearby points of interest: Missing Places configuration.";
     OCMVerify([self.coreMock log:ACPMobileLogLevelWarning
                              tag:ACPPlacesMonitorExtensionName_Test
                          message:errorString]);
+    OCMVerify([_monitor stopAllMonitoring:YES]);
 }
 
 - (void) testHandlePlacesRequestErrorConnectivity {


### PR DESCRIPTION
## Description

Take advantage of the new API in ACPPlaces which accepts an errorCallback parameter in the event that something has gone wrong.

## Related Issue

#21 , #29 

## Motivation and Context

More useful logging, especially when the Places extension does not have a list of nearby POIs to return.

## How Has This Been Tested?

Unit and manual testing.

