### PR TITLE
[AMSDK-8600] - Implement setRequestAuthorizationLevel API

### DIFF
--- a/ACPPlacesMonitor/ACPPlacesMonitor.h
+++ b/ACPPlacesMonitor/ACPPlacesMonitor.h
@@ -35,6 +35,24 @@ typedef NS_OPTIONS(NSInteger, ACPPlacesMonitorMode) {
 };
 
 /**
+ * @brief An enum indicating application's authorization to use location services
+ * @discussion
+ * - WhenInUse (ACPPlacesRequestAuthorizationLevelWhenInUse) : Requests the user’s permission to use location
+ *   services while the app is in use. The user prompt contains the text from the NSLocationWhenInUseUsageDescription
+ *   key in your app Info.plist file, and the presence of that key is required when calling this method. For more information
+ *   see : https://developer.apple.com/documentation/corelocation/cllocationmanager/1620562-requestwheninuseauthorization
+ * - Always (ACPPlacesRequestAuthorizationLevelAlways) : Use this enum to request for user permission to use location services
+ *   whether or not the app is in use. You must have NSLocationAlwaysUsageDescription and NSLocationWhenInUseUsageDescription
+ *   keys in your app’s Info.plist file definining the text that will appear during the user prompt.
+ *   see : https://developer.apple.com/documentation/corelocation/cllocationmanager/1620551-requestalwaysauthorization
+*/
+typedef NS_OPTIONS(NSInteger, ACPPlacesRequestAuthorizationLevel) {
+    ACPPlacesRequestAuthorizationLevelWhenInUse = 1 << 0,           /*!< Enum value ACPPlacesRequestAuthorizationLevelWhenInUse */
+    ACPPlacesRequestAuthorizationLevelAlways = 1 << 1    /*!< Enum value ACPPlacesRequestAuthorizationLevelAlways */
+};
+
+
+/**
  * @class ACPPlacesMonitor
  *
  * The ACPPlacesMonitor handles OS-level management of tracking the user's location and region monitoring.  It works
@@ -73,6 +91,21 @@ typedef NS_OPTIONS(NSInteger, ACPPlacesMonitorMode) {
  * @param monitorMode an ACPPlacesMonitorMode value indicating how the Places Monitor should track the user's location.
  */
 + (void) setPlacesMonitorMode: (ACPPlacesMonitorMode) monitorMode;
+
+/**
+ * @brief Sets the type of location authorization request, which the user will be prompted during Places Monitor start.
+ *
+ * @discussion Call this method before the Places Monitor start to set the approriate authorization prompt to be made to the user.
+ * Calling this method while actively monitoring will upgrade the location authorization level to the requested authorization value.
+ * This method has no effect if the provided requested authorization level is either already provided or denied by the application user.
+ * ACPPlacesRequestAuthorizationLevelAlways is the default request authorization value.
+ *
+ * The value provided in requestAuthorizationLevel will be persisted to NSUserDefaults for use cross-session.
+ * Important: Your app must be in the foreground to show a location authorization prompt.
+ *
+ * @param requestAuthorizationLevel an ACPPlacesRequestAuthorizationLevel value
+ */
++ (void) setRequestAuthorizationLevel: (ACPPlacesRequestAuthorizationLevel) requestAuthorizationLevel;
 
 /**
  * @brief Start tracking the device's location and monitoring their nearby Places

--- a/ACPPlacesMonitor/ACPPlacesMonitor.h
+++ b/ACPPlacesMonitor/ACPPlacesMonitor.h
@@ -93,18 +93,18 @@ typedef NS_OPTIONS(NSInteger, ACPPlacesRequestAuthorizationLevel) {
 + (void) setPlacesMonitorMode: (ACPPlacesMonitorMode) monitorMode;
 
 /**
- * @brief Sets the type of location authorization request, which the user will be prompted during Places Monitor start.
- *
- * @discussion Call this method before the Places Monitor start to set the approriate authorization prompt to be made to the user.
- * Calling this method while actively monitoring will upgrade the location authorization level to the requested authorization value.
- * This method has no effect if the provided requested authorization level is either already provided or denied by the application user.
- * ACPPlacesRequestAuthorizationLevelAlways is the default request authorization value.
- *
- * The value provided in requestAuthorizationLevel will be persisted to NSUserDefaults for use cross-session.
- * Important: Your app must be in the foreground to show a location authorization prompt.
- *
- * @param requestAuthorizationLevel an ACPPlacesRequestAuthorizationLevel value
- */
+* @brief Sets the type of location authorization request, which the user will be prompted during Places Monitor start.
+*
+* @discussion Call this method before the Places Monitor start to set the appropriate authorization prompt to be shown to the user.
+* Calling this method while actively monitoring will upgrade the location authorization level to the requested authorization value.
+* This method has no effect if the requested authorization level is either already provided or denied by the application user.
+* ACPPlacesRequestAuthorizationLevelAlways is the default request authorization value.
+*
+* The value provided in requestAuthorizationLevel will be persisted to NSUserDefaults for use cross-session.
+* Important: Your app must be in the foreground to show a location authorization prompt.
+*
+* @param requestAuthorizationLevel an ACPPlacesRequestAuthorizationLevel value
+*/
 + (void) setRequestAuthorizationLevel: (ACPPlacesRequestAuthorizationLevel) requestAuthorizationLevel;
 
 /**

--- a/ACPPlacesMonitor/ACPPlacesMonitor.m
+++ b/ACPPlacesMonitor/ACPPlacesMonitor.m
@@ -46,6 +46,11 @@
     [ACPPlacesMonitor dispatchMonitorEvent:ACPPlacesMonitorEventNameUpdateMonitorConfiguration withData:data];
 }
 
++ (void) setRequestAuthorizationLevel: (ACPPlacesRequestAuthorizationLevel) requestAuthorizationLevel {
+    NSDictionary* data = @ {ACPPlacesMonitorEventDataRequestAuthorizationLevel: @(requestAuthorizationLevel)};
+    [ACPPlacesMonitor dispatchMonitorEvent:ACPPlacesMonitorEventNameSetRequestAuthorizationLevel withData:data];
+}
+
 + (void) start {
     [ACPPlacesMonitor dispatchMonitorEvent:ACPPlacesMonitorEventNameStart withData:@ {}];
 }

--- a/ACPPlacesMonitor/ACPPlacesMonitorConstants.h
+++ b/ACPPlacesMonitor/ACPPlacesMonitorConstants.h
@@ -26,6 +26,8 @@ FOUNDATION_EXPORT int const ACPPlacesMonitorDefaultMaxMonitoredRegionCount;
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorDefaultsMonitoredRegions;
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorDefaultsUserWithinRegions;
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorDefaultsMonitorMode;
+FOUNDATION_EXPORT NSString* const ACPPlacesMonitorDefaultsRequestAuthorizationLevel;
+FOUNDATION_EXPORT NSString* const ACPPlacesMonitorDefaultsIsMonitoringStarted;
 
 #pragma mark - Event Data Keys
 // event sources
@@ -53,12 +55,17 @@ FOUNDATION_EXPORT NSString* const ACPPlacesMonitorRulesTriggeredConsequence;
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorRulesConsequenceType;
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorRulesConsequenceDetail;
 
-// places monitor
+// places monitor event names
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventNameStart;
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventNameStop;
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventNameUpdateLocationNow;
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventNameUpdateMonitorConfiguration;
+FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventNameSetRequestAuthorizationLevel;
+
+
+// places monitor eventData keys
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventDataMonitorMode;
+FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventDataRequestAuthorizationLevel;
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventDataClear;
 
 

--- a/ACPPlacesMonitor/ACPPlacesMonitorConstants.h
+++ b/ACPPlacesMonitor/ACPPlacesMonitorConstants.h
@@ -63,7 +63,7 @@ FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventNameUpdateMonitorConfigur
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventNameSetRequestAuthorizationLevel;
 
 
-// places monitor eventData keys
+// places monitor event data keys
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventDataMonitorMode;
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventDataRequestAuthorizationLevel;
 FOUNDATION_EXPORT NSString* const ACPPlacesMonitorEventDataClear;

--- a/ACPPlacesMonitor/ACPPlacesMonitorConstants.m
+++ b/ACPPlacesMonitor/ACPPlacesMonitorConstants.m
@@ -24,6 +24,8 @@ int const ACPPlacesMonitorDefaultMaxMonitoredRegionCount = 20;
 NSString* const ACPPlacesMonitorDefaultsMonitoredRegions = @"acpplacesmonitor.monitoredregions";
 NSString* const ACPPlacesMonitorDefaultsUserWithinRegions = @"acpplacesmonitor.userwithinregions";
 NSString* const ACPPlacesMonitorDefaultsMonitorMode = @"acpplacesmonitor.monitormode";
+NSString* const ACPPlacesMonitorDefaultsRequestAuthorizationLevel = @"acpplacesmonitor.requestauthorizationlevel";
+NSString* const ACPPlacesMonitorDefaultsIsMonitoringStarted = @"acpplacesmonitor.ismonitoringstarted";
 
 #pragma mark - Event Data Keys
 // event sources
@@ -51,10 +53,14 @@ NSString* const ACPPlacesMonitorRulesTriggeredConsequence = @"triggeredconsequen
 NSString* const ACPPlacesMonitorRulesConsequenceType = @"type";
 NSString* const ACPPlacesMonitorRulesConsequenceDetail = @"detail";
 
-// places monitor
+// places monitor event name
 NSString* const ACPPlacesMonitorEventNameStart = @"start monitoring";
 NSString* const ACPPlacesMonitorEventNameStop = @"stop monitoring";
 NSString* const ACPPlacesMonitorEventNameUpdateLocationNow = @"update location now";
 NSString* const ACPPlacesMonitorEventNameUpdateMonitorConfiguration = @"update monitor configuration";
+NSString* const ACPPlacesMonitorEventNameSetRequestAuthorizationLevel = @"set request authorization level";
+
+// places monitor event data keys
 NSString* const ACPPlacesMonitorEventDataMonitorMode = @"monitormode";
+NSString* const ACPPlacesMonitorEventDataRequestAuthorizationLevel = @"requestauthorizationlevel";
 NSString* const ACPPlacesMonitorEventDataClear = @"clearclientdata";

--- a/tests/ACPPlacesMonitorTests.m
+++ b/tests/ACPPlacesMonitorTests.m
@@ -99,6 +99,20 @@
                                         withData:testData]);
 }
 
+- (void) testSetRequestAuthorizationLevel {
+    // setup
+    ACPPlacesRequestAuthorizationLevel authLevel = ACPPlacesRequestAuthorizationLevelWhenInUse;
+    NSDictionary *testData = @{ACPPlacesMonitorEventDataRequestAuthorizationLevel_Test: @(authLevel)};
+    
+    // test
+    [ACPPlacesMonitor setRequestAuthorizationLevel:authLevel];
+    
+    // verify
+    OCMVerify([_monitorMock dispatchMonitorEvent:ACPPlacesMonitorEventNameSetRequestAuthorizationLevel_Test
+                                        withData:testData]);
+}
+
+
 - (void) testStart {
     // test
     [ACPPlacesMonitor start];
@@ -114,7 +128,7 @@
     
     // verify
     OCMVerify([_monitorMock dispatchMonitorEvent:ACPPlacesMonitorEventNameStop_Test
-                                        withData:@{ACPPlacesMonitorEventDataClear: @(YES)}]);
+                                        withData:@{ACPPlacesMonitorEventDataClear_Test: @(YES)}]);
 }
 
 - (void) testStopWithoutClear {
@@ -123,7 +137,7 @@
     
     // verify
     OCMVerify([_monitorMock dispatchMonitorEvent:ACPPlacesMonitorEventNameStop_Test
-                                        withData:@{ACPPlacesMonitorEventDataClear: @(NO)}]);
+                                        withData:@{ACPPlacesMonitorEventDataClear_Test: @(NO)}]);
 }
 
 - (void) testUpdateLocationNow {

--- a/tests/mocks/ACPPlacesMonitorConstantsTests.h
+++ b/tests/mocks/ACPPlacesMonitorConstantsTests.h
@@ -25,6 +25,8 @@ static int const ACPPlacesMonitorDefaultMaxMonitoredRegionCount_Test = 20;
 static NSString* const ACPPlacesMonitorDefaultsMonitoredRegions_Test = @"acpplacesmonitor.monitoredregions";
 static NSString* const ACPPlacesMonitorDefaultsUserWithinRegions_Test = @"acpplacesmonitor.userwithinregions";
 static NSString* const ACPPlacesMonitorDefaultsMonitorMode_Test = @"acpplacesmonitor.monitormode";
+static NSString* const ACPPlacesMonitorDefaultsRequestAuthorizationLevel_Test = @"acpplacesmonitor.requestauthorizationlevel";
+static NSString* const ACPPlacesMonitorDefaultsIsMonitoringStarted_Test = @"acpplacesmonitor.ismonitoringstarted";
 
 #pragma mark - Event Data Keys
 // event sources
@@ -57,7 +59,10 @@ static NSString* const ACPPlacesMonitorEventNameStart_Test = @"start monitoring"
 static NSString* const ACPPlacesMonitorEventNameStop_Test = @"stop monitoring";
 static NSString* const ACPPlacesMonitorEventNameUpdateLocationNow_Test = @"update location now";
 static NSString* const ACPPlacesMonitorEventNameUpdateMonitorConfiguration_Test = @"update monitor configuration";
+static NSString* const ACPPlacesMonitorEventNameSetRequestAuthorizationLevel_Test = @"set request authorization level";
+
 static NSString* const ACPPlacesMonitorEventDataMonitorMode_Test = @"monitormode";
-static NSString* const ACPPlacesMonitorEventDataClear = @"clearclientdata";
+static NSString* const ACPPlacesMonitorEventDataClear_Test = @"clearclientdata";
+static NSString* const ACPPlacesMonitorEventDataRequestAuthorizationLevel_Test = @"requestauthorizationlevel";
 
 #endif /* ACPPlacesMonitorConstantsTests_h */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding an API to facilitate prompting for required permission level in iOS.

<!--- Describe your changes in detail -->

The following API is added to the Places Monitor extension.
`+ (void) setRequestAuthorizationLevel: (ACPPlacesRequestAuthorizationLevel) requestAuthorizationLevel;
`
**Sample Usage:**

To request for WhenInUse permission
```
// set the request authorization level
[ACPPlacesMonitor setRequestAuthorizationLevel: ACPPlacesRequestAuthorizationLevelWhenInUse];
// start monitoring
[ACPPlacesMonitor start];

```

Further when its required to upgrade to Always Allow authorization
```
// set the request authorization level
[ACPPlacesMonitor setRequestAuthorizationLevel: ACPPlacesRequestAuthorizationLevelAlways];
```



## Related Issue
https://jira.corp.adobe.com/browse/AMSDK-8600

## Motivation and Context
Places monitor being flexible enough to request and upgrade permission as and when the app user needs it.

## How Has This Been Tested?

This feature is tested on Simulator and on devices (iOS 12 and 13) by calling the setRequestAuthorizationLevel with different values.

## Screenshots (if appropriate):

**iOS 12 dialog - When In Use permission** 
<img width="544" alt="Screen Shot 2019-10-01 at 11 15 08 AM" src="https://user-images.githubusercontent.com/8909148/65988761-47c8f100-e43d-11e9-8739-e31be7682ed7.png">

**iOS 12 dialog - Always allow permission** 
<img width="544" alt="Screen Shot 2019-10-01 at 11 15 15 AM" src="https://user-images.githubusercontent.com/8909148/65988777-544d4980-e43d-11e9-8e90-f08a38b91c17.png">

**iOS 13 dialog - whenInUse/ Always allow permission**
![Screen Shot 2019-10-01 at 11 17 10 AM](https://user-images.githubusercontent.com/8909148/65988826-6b8c3700-e43d-11e9-9c8f-37105ee4f1a4.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
-  [] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.