### PR TITLE
#51 - reporting clauthorizationstatus to places

### DIFF
--- a/ACPPlacesMonitor.podspec
+++ b/ACPPlacesMonitor.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "ACPPlacesMonitor"
-  s.version      = "2.1.1"
+  s.version      = "2.1.2"
   s.summary      = "Places monitor for Adobe Experience Cloud SDK. Written and maintained by Adobe."
   s.description  = <<-DESC
                    The Places monitor provides native geolocation functionality, enabling use of the Places product in the V5 Adobe Experience Cloud SDK.
@@ -18,8 +18,8 @@ Pod::Spec.new do |s|
 
   s.static_framework = true
 
-  s.dependency "ACPCore", ">= 2.3.4"
-  s.dependency "ACPPlaces", ">= 1.2.0"
+  s.dependency "ACPCore", ">= 2.3.6"
+  s.dependency "ACPPlaces", ">= 1.3.0"
 
   s.subspec "iOS" do |ios|
     ios.public_header_files = "ACPPlacesMonitor/ACPPlacesMonitor.h"

--- a/ACPPlacesMonitor/ACPPlacesMonitor.h
+++ b/ACPPlacesMonitor/ACPPlacesMonitor.h
@@ -12,7 +12,7 @@
 
 //
 // ACPPlacesMonitor.h
-// Places Monitor Version: 2.1.1
+// Places Monitor Version: 2.1.2
 //
 
 #import <Foundation/Foundation.h>

--- a/ACPPlacesMonitor/ACPPlacesMonitorConstants.m
+++ b/ACPPlacesMonitor/ACPPlacesMonitorConstants.m
@@ -17,7 +17,7 @@
 #import "ACPPlacesMonitorConstants.h"
 
 #pragma mark - Monitor Properties
-NSString* const ACPPlacesMonitorExtensionVersion = @"2.1.1";
+NSString* const ACPPlacesMonitorExtensionVersion = @"2.1.2";
 NSString* const ACPPlacesMonitorExtensionName = @"com.adobe.placesMonitor";
 int const ACPPlacesMonitorDefaultMaxMonitoredRegionCount = 20;
 

--- a/ACPPlacesMonitor/ACPPlacesMonitorLocationDelegate.m
+++ b/ACPPlacesMonitor/ACPPlacesMonitorLocationDelegate.m
@@ -136,6 +136,9 @@
     [ACPCore log:ACPMobileLogLevelDebug
              tag:ACPPlacesMonitorExtensionName
          message:[NSString stringWithFormat:@"Authorization status changed: %@", [self authStatusString:status]]];
+    
+    // update the places shared state
+    [ACPPlaces setAuthorizationStatus:status];
 }
 
 #pragma mark - other delegate methods

--- a/Podfile
+++ b/Podfile
@@ -4,12 +4,12 @@ workspace 'ACPPlacesMonitor'
 project 'ACPPlacesMonitor.xcodeproj'
 
 target 'ACPPlacesMonitor_iOS' do
-  pod 'ACPCore', '>= 2.1.0'
-  pod 'ACPPlaces', '>= 1.0.0'
+  pod 'ACPCore', '>= 2.3.6'
+  pod 'ACPPlaces', '>= 1.3.0'
 end
 
 target 'ACPPlacesMonitor-iOS-unit-tests' do
-  pod 'ACPCore', '>= 2.1.0'
-  pod 'ACPPlaces', '>= 1.0.0'
+  pod 'ACPCore', '>= 2.3.6'
+  pod 'ACPPlaces', '>= 1.3.0'
   pod 'OCMock', '3.4.3'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,16 +2,16 @@ PODS:
   - ACPCore (2.3.6):
     - ACPCore/iOS (= 2.3.6)
   - ACPCore/iOS (2.3.6)
-  - ACPPlaces (1.2.0):
-    - ACPCore (>= 2.3.2)
-    - ACPPlaces/iOS (= 1.2.0)
-  - ACPPlaces/iOS (1.2.0):
-    - ACPCore (>= 2.3.2)
+  - ACPPlaces (1.3.0):
+    - ACPCore (>= 2.3.6)
+    - ACPPlaces/iOS (= 1.3.0)
+  - ACPPlaces/iOS (1.3.0):
+    - ACPCore (>= 2.3.6)
   - OCMock (3.4.3)
 
 DEPENDENCIES:
-  - ACPCore (>= 2.1.0)
-  - ACPPlaces (>= 1.0.0)
+  - ACPCore (>= 2.3.6)
+  - ACPPlaces (>= 1.3.0)
   - OCMock (= 3.4.3)
 
 SPEC REPOS:
@@ -22,9 +22,9 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   ACPCore: 1d3a5b79f172de3d998cf63b5c1538da1dd66f33
-  ACPPlaces: 35401daa06d6b4bb9cfb91cce62e07d871aa0f10
+  ACPPlaces: deef721ad68ce9abb2b547183a0a9ec326454400
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
 
-PODFILE CHECKSUM: e6b5f1a437e9254655924c3febf1f623ef768d43
+PODFILE CHECKSUM: b79127b500aa51cc2fc16181b75acbd1dc0dd69c
 
 COCOAPODS: 1.8.4

--- a/tests/ACPPlacesMonitorLocationDelegateTests.m
+++ b/tests/ACPPlacesMonitorLocationDelegateTests.m
@@ -351,4 +351,15 @@
     XCTAssertEqual(@"Not Determined", result);
 }
 
+- (void) testAuthStatusChangeReportedToPlaces {
+    // setup
+    id placesMock = OCMClassMock([ACPPlaces class]);
+        
+    // test
+    [_locationDelegate locationManager:_manager didChangeAuthorizationStatus:kCLAuthorizationStatusAuthorizedAlways];
+    
+    // verify
+    OCMVerify([placesMock setAuthorizationStatus:kCLAuthorizationStatusAuthorizedAlways]);
+}
+
 @end

--- a/tests/mocks/ACPPlacesMonitorConstantsTests.h
+++ b/tests/mocks/ACPPlacesMonitorConstantsTests.h
@@ -18,7 +18,7 @@
 #define ACPPlacesMonitorConstantsTests_h
 
 #pragma mark - Monitor Properties
-static NSString* const ACPPlacesMonitorExtensionVersion_Test = @"2.1.1";
+static NSString* const ACPPlacesMonitorExtensionVersion_Test = @"2.1.2";
 static NSString* const ACPPlacesMonitorExtensionName_Test = @"com.adobe.placesMonitor";
 static int const ACPPlacesMonitorDefaultMaxMonitoredRegionCount_Test = 20;
 


### PR DESCRIPTION
## Description

ACPPlaces has a new API to collect device authorization status for location use.  This PR passes along any changed status reported to the CLLocationManager by the OS.

## Related Issue

#51 